### PR TITLE
Provide a specialized filter method

### DIFF
--- a/Sources/SortedArray.swift
+++ b/Sources/SortedArray.swift
@@ -97,6 +97,10 @@ extension SortedArray: RandomAccessCollection {
     public subscript(position: Index) -> Element {
         return _elements[position]
     }
+
+    public func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> SortedArray<Element> {
+        return SortedArray(sorted: try filter(isIncluded), areInIncreasingOrder: areInIncreasingOrder)
+    }
 }
 
 extension SortedArray: CustomStringConvertible, CustomDebugStringConvertible {

--- a/Tests/SortedArrayTests/SortedArrayTests.swift
+++ b/Tests/SortedArrayTests/SortedArrayTests.swift
@@ -151,6 +151,11 @@ class SortedArrayTests: XCTestCase {
         let description = String(reflecting: sut)
         XCTAssertEqual(description, "<SortedArray> [\"a\", \"b\", \"c\"]")
     }
+
+    func testFilter() {
+        let sut = SortedArray(unsorted: ["a", "b", "c"])
+        assertElementsEqual(sut.filter { $0 != "a" }, ["b", "c"])
+    }
 }
 
 extension SortedArrayTests {


### PR DESCRIPTION
Overrides filter to return a SortedArray, instead of a Swift.Array.