### PR TITLE
Filter fixes

### DIFF
--- a/Sources/SortedArray.swift
+++ b/Sources/SortedArray.swift
@@ -99,7 +99,8 @@ extension SortedArray: RandomAccessCollection {
     }
 
     public func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> SortedArray<Element> {
-        return SortedArray(sorted: try filter(isIncluded), areInIncreasingOrder: areInIncreasingOrder)
+        let newElements: [Element] = try filter(isIncluded)
+        return SortedArray(sorted: newElements, areInIncreasingOrder: areInIncreasingOrder)
     }
 }
 

--- a/Tests/SortedArrayTests/SortedArrayTests.swift
+++ b/Tests/SortedArrayTests/SortedArrayTests.swift
@@ -183,7 +183,8 @@ extension SortedArrayTests {
             ("testMin", testMin),
             ("testMax", testMax),
             ("testCustomStringConvertible", testCustomStringConvertible),
-            ("testCustomDebugStringConvertible", testCustomDebugStringConvertible)
+            ("testCustomDebugStringConvertible", testCustomDebugStringConvertible),
+            ("testFilter", testFilter),
         ]
     }
 }


### PR DESCRIPTION
1. Forgot to add filter test method to the test suite in #2 
2. `filter` caused an infinite loop because we weren't explicit about which `filter` to use; Swift picked our own implementation and we want the implementation on `Sequence`.

