### PR TITLE
resolve ambiguous Indices typealias

### DIFF
--- a/Sources/SortedArray.swift
+++ b/Sources/SortedArray.swift
@@ -82,6 +82,7 @@ extension SortedArray where Element: Comparable {
 
 extension SortedArray: RandomAccessCollection {
     public typealias Index = Int
+    public typealias Indices = CountableRange<Index>
 
     public var startIndex: Index { return _elements.startIndex }
     public var endIndex: Index { return _elements.endIndex }


### PR DESCRIPTION
Without this, it doesn't compile for me with Swift 3.0/Xcode 8.2.1 🤔