### PR TITLE
Use normal build system

### DIFF
--- a/SortedArray.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/SortedArray.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Latest</string>
-</dict>
+<dict/>
 </plist>


### PR DESCRIPTION
Carthage fails to install SortedArray if it's configured to use the new
build system by default.