### PR TITLE
index(of:) must return index of first matching element when there are duplicates

### DIFF
--- a/SortedArray.xcodeproj/project.pbxproj
+++ b/SortedArray.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		52D6D9EA1BEFFFA4002C0205 /* SortedArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9961BEFF375002C0205 /* SortedArray.swift */; };
 		52D6DA091BF00081002C0205 /* SortedArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9961BEFF375002C0205 /* SortedArray.swift */; };
 		52D6DA261BF00118002C0205 /* SortedArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9961BEFF375002C0205 /* SortedArray.swift */; };
+		5D6634252003E2C000364E93 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6634242003E2C000364E93 /* PerformanceTests.swift */; };
+		5D6634262003E2C000364E93 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6634242003E2C000364E93 /* PerformanceTests.swift */; };
+		5D6634272003E2C000364E93 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6634242003E2C000364E93 /* PerformanceTests.swift */; };
 		5DA058D21E8813F3006FA2B1 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA058D11E8813F3006FA2B1 /* TestHelpers.swift */; };
 		5DA058D31E8813F3006FA2B1 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA058D11E8813F3006FA2B1 /* TestHelpers.swift */; };
 		5DA058D41E8813F3006FA2B1 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA058D11E8813F3006FA2B1 /* TestHelpers.swift */; };
@@ -54,6 +57,7 @@
 		52D6D9E21BEFFF6E002C0205 /* SortedArray.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SortedArray.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9F01BEFFFBE002C0205 /* SortedArray.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SortedArray.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6DA0F1BF000BD002C0205 /* SortedArray.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SortedArray.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5D6634242003E2C000364E93 /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PerformanceTests.swift; path = Tests/SortedArrayTests/PerformanceTests.swift; sourceTree = "<group>"; };
 		5DA058D11E8813F3006FA2B1 /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestHelpers.swift; path = Tests/SortedArrayTests/TestHelpers.swift; sourceTree = "<group>"; };
 		AD2FAA261CD0B6D800659CF4 /* SortedArray.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SortedArray.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* SortedArrayTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SortedArrayTests.plist; sourceTree = "<group>"; };
@@ -122,6 +126,7 @@
 			children = (
 				52D6D9961BEFF375002C0205 /* SortedArray.swift */,
 				52D6D9971BEFF375002C0205 /* SortedArrayTests.swift */,
+				5D6634242003E2C000364E93 /* PerformanceTests.swift */,
 				5DA058D11E8813F3006FA2B1 /* TestHelpers.swift */,
 				52D6D99C1BEFF38C002C0205 /* Configs */,
 				52D6D97D1BEFF229002C0205 /* Products */,
@@ -456,6 +461,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				52D6D99B1BEFF375002C0205 /* SortedArrayTests.swift in Sources */,
+				5D6634252003E2C000364E93 /* PerformanceTests.swift in Sources */,
 				5DA058D21E8813F3006FA2B1 /* TestHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -489,6 +495,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DD7502861C68FDDC006590AF /* SortedArrayTests.swift in Sources */,
+				5D6634262003E2C000364E93 /* PerformanceTests.swift in Sources */,
 				5DA058D31E8813F3006FA2B1 /* TestHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -498,6 +505,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DD75029A1C690CBE006590AF /* SortedArrayTests.swift in Sources */,
+				5D6634272003E2C000364E93 /* PerformanceTests.swift in Sources */,
 				5DA058D41E8813F3006FA2B1 /* TestHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SortedArray.xcodeproj/xcshareddata/xcbaselines/DD7502791C68FCFC006590AF.xcbaseline/28BBA58F-EC4C-4E7A-943A-5B8FD5CC1F33.plist
+++ b/SortedArray.xcodeproj/xcshareddata/xcbaselines/DD7502791C68FCFC006590AF.xcbaseline/28BBA58F-EC4C-4E7A-943A-5B8FD5CC1F33.plist
@@ -4,6 +4,29 @@
 <dict>
 	<key>classNames</key>
 	<dict>
+		<key>PerformanceTests</key>
+		<dict>
+			<key>testPerformanceOfIndexOf()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.3423</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPerformanceOfLastIndexOf()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.34701</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
 		<key>SortedArrayTests</key>
 		<dict>
 			<key>testIndexOfPerformance()</key>

--- a/SortedArray.xcodeproj/xcshareddata/xcbaselines/DD7502791C68FCFC006590AF.xcbaseline/28BBA58F-EC4C-4E7A-943A-5B8FD5CC1F33.plist
+++ b/SortedArray.xcodeproj/xcshareddata/xcbaselines/DD7502791C68FCFC006590AF.xcbaseline/28BBA58F-EC4C-4E7A-943A-5B8FD5CC1F33.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>SortedArrayTests</key>
+		<dict>
+			<key>testIndexOfPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.32278</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/SortedArray.xcodeproj/xcshareddata/xcbaselines/DD7502791C68FCFC006590AF.xcbaseline/28BBA58F-EC4C-4E7A-943A-5B8FD5CC1F33.plist
+++ b/SortedArray.xcodeproj/xcshareddata/xcbaselines/DD7502791C68FCFC006590AF.xcbaseline/28BBA58F-EC4C-4E7A-943A-5B8FD5CC1F33.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.3423</real>
+					<real>0</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -21,7 +21,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.34701</real>
+					<real>0</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/SortedArray.xcodeproj/xcshareddata/xcbaselines/DD7502791C68FCFC006590AF.xcbaseline/Info.plist
+++ b/SortedArray.xcodeproj/xcshareddata/xcbaselines/DD7502791C68FCFC006590AF.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>28BBA58F-EC4C-4E7A-943A-5B8FD5CC1F33</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2600</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>MacBookPro11,2</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sources/SortedArray.swift
+++ b/Sources/SortedArray.swift
@@ -245,7 +245,7 @@ extension SortedArray {
         guard var match = anyIndex(of: element) else { return nil }
         // Walk backward to find the first matching element (in case there are duplicates)
         while let predecessor = index(match, offsetBy: -1, limitedBy: startIndex) {
-            if compare(lhs: self[predecessor], rhs: element) == .orderedSame {
+            if compare(self[predecessor], element) == .orderedSame {
                 match = predecessor
             } else {
                 break
@@ -304,7 +304,7 @@ extension SortedArray {
         // Walk forward to find the last matching element (in case there are duplicates)
         let lastValidIndex = index(before: endIndex)
         while let successor = index(match, offsetBy: 1, limitedBy: lastValidIndex) {
-            if compare(lhs: self[successor], rhs: element) == .orderedSame {
+            if compare(self[successor], element) == .orderedSame {
                 match = successor
             } else {
                 break
@@ -316,7 +316,7 @@ extension SortedArray {
 
 // MARK: - Converting between a stdlib comparator function and Foundation.ComparisonResult
 extension SortedArray {
-    fileprivate func compare(lhs: Element, rhs: Element) -> Foundation.ComparisonResult {
+    fileprivate func compare(_ lhs: Element, _ rhs: Element) -> Foundation.ComparisonResult {
         if areInIncreasingOrder(lhs, rhs) {
             return .orderedAscending
         } else if areInIncreasingOrder(rhs, lhs) {
@@ -346,18 +346,18 @@ fileprivate enum Match<Index: Comparable> {
 }
 
 extension SortedArray {
-    /// Searches the array for `newElement` using binary search.
+    /// Searches the array for `element` using binary search.
     ///
-    /// - Returns: If `newElement` is in the array, returns `.found(at: index)`
+    /// - Returns: If `element` is in the array, returns `.found(at: index)`
     ///   where `index` is the index of the element in the array.
-    ///   If `newElement` is not in the array, returns `.notFound(insertAt: index)`
+    ///   If `element` is not in the array, returns `.notFound(insertAt: index)`
     ///   where `index` is the index where the element should be inserted to 
     ///   preserve the sort order.
-    ///   If the array contains multiple elements that are equal to `newElement`,
+    ///   If the array contains multiple elements that are equal to `element`,
     ///   there is no guarantee which of these is found.
     ///
     /// - Complexity: O(_log(n)_), where _n_ is the size of the array.
-    fileprivate func search(for newElement: Element) -> Match<Index> {
+    fileprivate func search(for element: Element) -> Match<Index> {
         guard !isEmpty else { return .notFound(insertAt: endIndex) }
         var left = startIndex
         var right = index(before: endIndex)
@@ -367,7 +367,7 @@ extension SortedArray {
             let mid = index(left, offsetBy: dist/2)
             let candidate = self[mid]
 
-            switch compare(lhs: candidate, rhs: newElement) {
+            switch compare(candidate, element) {
             case .orderedAscending:
                 left = index(after: mid)
             case .orderedDescending:

--- a/Sources/SortedArray.swift
+++ b/Sources/SortedArray.swift
@@ -291,6 +291,27 @@ extension SortedArray {
         case .notFound(insertAt: _): return nil
         }
     }
+
+    /// Returns the last index where the specified value appears in the collection.
+    /// After having found a matching index through binary search, the algorithm
+    /// iterates linearly through the array to find the last matching index.
+    ///
+    /// - Complexity: O(_log(n)_) in the general case, where _n_ is the size of the array.
+    ///   The worst-case performance could be O(_n_) if the array contains nothing
+    ///   but duplicates of the searched element.
+    public func lastIndex(of element: Element) -> Index? {
+        guard var match = anyIndex(of: element) else { return nil }
+        // Walk forward to find the last matching element (in case there are duplicates)
+        let lastValidIndex = index(before: endIndex)
+        while let successor = index(match, offsetBy: 1, limitedBy: lastValidIndex) {
+            if compare(lhs: self[successor], rhs: element) == .orderedSame {
+                match = successor
+            } else {
+                break
+            }
+        }
+        return match
+    }
 }
 
 // MARK: - Converting between a stdlib comparator function and Foundation.ComparisonResult

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,4 +3,5 @@ import XCTest
 
 XCTMain([
      testCase(SortedArrayTests.allTests),
+     testCase(PerformanceTests.allTests),
 ])

--- a/Tests/SortedArrayTests/PerformanceTests.swift
+++ b/Tests/SortedArrayTests/PerformanceTests.swift
@@ -1,0 +1,42 @@
+import SortedArray
+import XCTest
+
+class PerformanceTests: XCTestCase {
+    func testLinuxTestSuiteIncludesAllTests() {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+            #if swift(>=4.0)
+                let darwinTestCount = PerformanceTests.defaultTestSuite.testCaseCount
+            #else
+                let darwinTestCount = Int(PerformanceTests.defaultTestSuite().testCaseCount)
+            #endif
+            let linuxTestCount = PerformanceTests.allTests.count
+            XCTAssertEqual(linuxTestCount, darwinTestCount, "allTests (used for testing on Linux) is missing \(darwinTestCount - linuxTestCount) tests")
+        #endif
+    }
+
+    func testPerformanceOfIndexOf() {
+        let sourceArray = Array(repeating: 500, count: 1_000_000) + Array(repeating: 40, count: 1_000_000) + Array(repeating: 3, count: 1_000_000)
+        let sut = SortedArray(unsorted: sourceArray)
+        measure {
+            XCTAssertEqual(sut.index(of: 500), 2_000_000)
+        }
+    }
+
+    func testPerformanceOfLastIndexOf() {
+        let sourceArray = Array(repeating: 500, count: 1_000_000) + Array(repeating: 40, count: 1_000_000) + Array(repeating: 3, count: 1_000_000)
+        let sut = SortedArray(unsorted: sourceArray)
+        measure {
+            XCTAssertEqual(sut.lastIndex(of: 3), 999_999)
+        }
+    }
+}
+
+extension PerformanceTests {
+    static var allTests : [(String, (PerformanceTests) -> () throws -> Void)] {
+        return [
+            ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
+            ("testPerformanceOfIndexOf", testPerformanceOfIndexOf),
+            ("testPerformanceOfLastIndexOf", testPerformanceOfLastIndexOf),
+        ]
+    }
+}

--- a/Tests/SortedArrayTests/SortedArrayTests.swift
+++ b/Tests/SortedArrayTests/SortedArrayTests.swift
@@ -130,6 +130,18 @@ class SortedArrayTests: XCTestCase {
         XCTAssertNil(index)
     }
 
+    func testIndexOfReturnsNilForEmptyArray() {
+        let sut = SortedArray<Int>()
+        let index = sut.index(of: 1)
+        XCTAssertNil(index)
+    }
+
+    func testIndexOfCanDealWithSingleElementArray() {
+        let sut = SortedArray<Int>(unsorted: [5])
+        let index = sut.index(of: 5)
+        XCTAssertEqual(index, 0)
+    }
+
     func testIndexOfFindsFirstIndexOfDuplicateElements1() {
         let sut = SortedArray(unsorted: [1,2,3,3,3,3,3,3,3,3,4,5])
         let index = sut.index(of: 3)
@@ -183,6 +195,18 @@ class SortedArrayTests: XCTestCase {
         let sut = SortedArray(unsorted: "Hello World".characters)
         let index = sut.lastIndex(of: "h")
         XCTAssertNil(index)
+    }
+
+    func testLastIndexOfReturnsNilForEmptyArray() {
+        let sut = SortedArray<Int>()
+        let index = sut.lastIndex(of: 1)
+        XCTAssertNil(index)
+    }
+
+    func testLastIndexOfCanDealWithSingleElementArray() {
+        let sut = SortedArray<Int>(unsorted: [5])
+        let index = sut.lastIndex(of: 5)
+        XCTAssertEqual(index, 0)
     }
 
     func testLastIndexOfFindsLastIndexOfDuplicateElements1() {
@@ -331,6 +355,8 @@ extension SortedArrayTests {
             ("testIndexOfFindsFirstElement", testIndexOfFindsFirstElement),
             ("testIndexOfFindsLastElement", testIndexOfFindsLastElement),
             ("testIndexOfReturnsNilWhenNotFound", testIndexOfReturnsNilWhenNotFound),
+            ("testIndexOfReturnsNilForEmptyArray", testIndexOfReturnsNilForEmptyArray),
+            ("testIndexOfCanDealWithSingleElementArray", testIndexOfCanDealWithSingleElementArray),
             ("testIndexOfFindsFirstIndexOfDuplicateElements1", testIndexOfFindsFirstIndexOfDuplicateElements1),
             ("testIndexOfFindsFirstIndexOfDuplicateElements2", testIndexOfFindsFirstIndexOfDuplicateElements2),
             ("testIndexOfFindsFirstIndexOfDuplicateElements3", testIndexOfFindsFirstIndexOfDuplicateElements3),
@@ -340,6 +366,8 @@ extension SortedArrayTests {
             ("testLastIndexOfFindsFirstElement", testLastIndexOfFindsFirstElement),
             ("testLastIndexOfFindsLastElement", testLastIndexOfFindsLastElement),
             ("testLastIndexOfReturnsNilWhenNotFound", testLastIndexOfReturnsNilWhenNotFound),
+            ("testLastIndexOfReturnsNilForEmptyArray", testLastIndexOfReturnsNilForEmptyArray),
+            ("testLastIndexOfCanDealWithSingleElementArray", testLastIndexOfCanDealWithSingleElementArray),
             ("testLastIndexOfFindsLastIndexOfDuplicateElements1", testLastIndexOfFindsLastIndexOfDuplicateElements1),
             ("testLastIndexOfFindsLastIndexOfDuplicateElements2", testLastIndexOfFindsLastIndexOfDuplicateElements2),
             ("testLastIndexOfFindsLastIndexOfDuplicateElements3", testLastIndexOfFindsLastIndexOfDuplicateElements3),

--- a/Tests/SortedArrayTests/SortedArrayTests.swift
+++ b/Tests/SortedArrayTests/SortedArrayTests.swift
@@ -148,6 +148,19 @@ class SortedArrayTests: XCTestCase {
         XCTAssertEqual(index, 0)
     }
 
+    func testIndexOfFindsFirstIndexOfDuplicateElements4() {
+        let sut = SortedArray<Character>(unsorted: Array(repeating: "a", count: 100_000))
+        let index = sut.index(of: "a")
+        XCTAssertEqual(index, 0)
+    }
+
+    func testIndexOfFindsFirstIndexOfDuplicateElements5() {
+        let sourceArray = Array(repeating: 5, count: 100_000) + [1,2,6,7,8,9]
+        let sut = SortedArray(unsorted: sourceArray)
+        let index = sut.index(of: 5)
+        XCTAssertEqual(index, 2)
+    }
+
     func testLastIndexOfFindsElementInMiddle() {
         let sut = SortedArray(unsorted: ["a","z","r","k"])
         let index = sut.lastIndex(of: "k")
@@ -321,6 +334,8 @@ extension SortedArrayTests {
             ("testIndexOfFindsFirstIndexOfDuplicateElements1", testIndexOfFindsFirstIndexOfDuplicateElements1),
             ("testIndexOfFindsFirstIndexOfDuplicateElements2", testIndexOfFindsFirstIndexOfDuplicateElements2),
             ("testIndexOfFindsFirstIndexOfDuplicateElements3", testIndexOfFindsFirstIndexOfDuplicateElements3),
+            ("testIndexOfFindsFirstIndexOfDuplicateElements4", testIndexOfFindsFirstIndexOfDuplicateElements4),
+            ("testIndexOfFindsFirstIndexOfDuplicateElements5", testIndexOfFindsFirstIndexOfDuplicateElements4),
             ("testLastIndexOfFindsElementInMiddle", testLastIndexOfFindsElementInMiddle),
             ("testLastIndexOfFindsFirstElement", testLastIndexOfFindsFirstElement),
             ("testLastIndexOfFindsLastElement", testLastIndexOfFindsLastElement),

--- a/Tests/SortedArrayTests/SortedArrayTests.swift
+++ b/Tests/SortedArrayTests/SortedArrayTests.swift
@@ -286,15 +286,15 @@ class SortedArrayTests: XCTestCase {
         assertElementsEqual(sut, [1,2])
     }
 
-  func testIsEqual() {
-      let sut = SortedArray(unsorted: [3,2,1])
-      XCTAssertTrue(sut == SortedArray(unsorted: 1...3))
-  }
+    func testIsEqual() {
+        let sut = SortedArray(unsorted: [3,2,1])
+        XCTAssertTrue(sut == SortedArray(unsorted: 1...3))
+    }
 
-  func testIsNotEqual() {
-      let sut = SortedArray(unsorted: 1...3)
-      XCTAssertTrue(sut != SortedArray(unsorted: 1...4))
-  }
+    func testIsNotEqual() {
+        let sut = SortedArray(unsorted: 1...3)
+        XCTAssertTrue(sut != SortedArray(unsorted: 1...4))
+    }
 }
 
 extension SortedArrayTests {

--- a/Tests/SortedArrayTests/SortedArrayTests.swift
+++ b/Tests/SortedArrayTests/SortedArrayTests.swift
@@ -130,10 +130,22 @@ class SortedArrayTests: XCTestCase {
         XCTAssertNil(index)
     }
 
-    func testIndexOfReturnsFirstMatchForDuplicates() {
-        let sut = SortedArray(unsorted: "abcabcabc".characters)
-        let index = sut.index(of: "c")
-        XCTAssertEqual(index, 6)
+    func testIndexOfFindsFirstIndexOfDuplicateElements1() {
+        let sut = SortedArray(unsorted: [1,2,3,3,3,3,3,3,3,3,4,5])
+        let index = sut.index(of: 3)
+        XCTAssertEqual(index, 2)
+    }
+
+    func testIndexOfFindsFirstIndexOfDuplicateElements2() {
+        let sut = SortedArray(unsorted: [1,4,4,4,4,4,4,4,4,3,2])
+        let index = sut.index(of: 4)
+        XCTAssertEqual(index, 3)
+    }
+
+    func testIndexOfFindsFirstIndexOfDuplicateElements3() {
+        let sut = SortedArray(unsorted: String(repeating: "A", count: 10).characters)
+        let index = sut.index(of: "A")
+        XCTAssertEqual(index, 0)
     }
 
     func testsContains() {
@@ -264,7 +276,9 @@ extension SortedArrayTests {
             ("testIndexOfFindsFirstElement", testIndexOfFindsFirstElement),
             ("testIndexOfFindsLastElement", testIndexOfFindsLastElement),
             ("testIndexOfReturnsNilWhenNotFound", testIndexOfReturnsNilWhenNotFound),
-            ("testIndexOfReturnsFirstMatchForDuplicates", testIndexOfReturnsFirstMatchForDuplicates),
+            ("testIndexOfFindsFirstIndexOfDuplicateElements1", testIndexOfFindsFirstIndexOfDuplicateElements1),
+            ("testIndexOfFindsFirstIndexOfDuplicateElements2", testIndexOfFindsFirstIndexOfDuplicateElements2),
+            ("testIndexOfFindsFirstIndexOfDuplicateElements3", testIndexOfFindsFirstIndexOfDuplicateElements3),
             ("testsContains", testsContains),
             ("testMin", testMin),
             ("testMax", testMax),

--- a/Tests/SortedArrayTests/SortedArrayTests.swift
+++ b/Tests/SortedArrayTests/SortedArrayTests.swift
@@ -148,6 +148,48 @@ class SortedArrayTests: XCTestCase {
         XCTAssertEqual(index, 0)
     }
 
+    func testLastIndexOfFindsElementInMiddle() {
+        let sut = SortedArray(unsorted: ["a","z","r","k"])
+        let index = sut.lastIndex(of: "k")
+        XCTAssertEqual(index, 1)
+    }
+
+    func testLastIndexOfFindsFirstElement() {
+        let sut = SortedArray(sorted: 1..<10)
+        let index = sut.lastIndex(of: 1)
+        XCTAssertEqual(index, 0)
+    }
+
+    func testLastIndexOfFindsLastElement() {
+        let sut = SortedArray(sorted: 1..<10)
+        let index = sut.lastIndex(of: 9)
+        XCTAssertEqual(index, 8)
+    }
+
+    func testLastIndexOfReturnsNilWhenNotFound() {
+        let sut = SortedArray(unsorted: "Hello World".characters)
+        let index = sut.lastIndex(of: "h")
+        XCTAssertNil(index)
+    }
+
+    func testLastIndexOfFindsLastIndexOfDuplicateElements1() {
+        let sut = SortedArray(unsorted: [1,2,3,3,3,3,3,3,3,3,4,5])
+        let index = sut.lastIndex(of: 3)
+        XCTAssertEqual(index, 9)
+    }
+
+    func testLastIndexOfFindsLastIndexOfDuplicateElements2() {
+        let sut = SortedArray(unsorted: [1,4,4,4,4,4,4,4,4,3,2])
+        let index = sut.lastIndex(of: 4)
+        XCTAssertEqual(index, 10)
+    }
+
+    func testLastIndexOfFindsLastIndexOfDuplicateElements3() {
+        let sut = SortedArray(unsorted: String(repeating: "A", count: 10).characters)
+        let index = sut.lastIndex(of: "A")
+        XCTAssertEqual(index, 9)
+    }
+
     func testsContains() {
         let sut = SortedArray(unsorted: "Lorem ipsum".characters)
         XCTAssertTrue(sut.contains(" "))
@@ -279,6 +321,13 @@ extension SortedArrayTests {
             ("testIndexOfFindsFirstIndexOfDuplicateElements1", testIndexOfFindsFirstIndexOfDuplicateElements1),
             ("testIndexOfFindsFirstIndexOfDuplicateElements2", testIndexOfFindsFirstIndexOfDuplicateElements2),
             ("testIndexOfFindsFirstIndexOfDuplicateElements3", testIndexOfFindsFirstIndexOfDuplicateElements3),
+            ("testLastIndexOfFindsElementInMiddle", testLastIndexOfFindsElementInMiddle),
+            ("testLastIndexOfFindsFirstElement", testLastIndexOfFindsFirstElement),
+            ("testLastIndexOfFindsLastElement", testLastIndexOfFindsLastElement),
+            ("testLastIndexOfReturnsNilWhenNotFound", testLastIndexOfReturnsNilWhenNotFound),
+            ("testLastIndexOfFindsLastIndexOfDuplicateElements1", testLastIndexOfFindsLastIndexOfDuplicateElements1),
+            ("testLastIndexOfFindsLastIndexOfDuplicateElements2", testLastIndexOfFindsLastIndexOfDuplicateElements2),
+            ("testLastIndexOfFindsLastIndexOfDuplicateElements3", testLastIndexOfFindsLastIndexOfDuplicateElements3),
             ("testsContains", testsContains),
             ("testMin", testMin),
             ("testMax", testMax),

--- a/Tests/SortedArrayTests/SortedArrayTests.swift
+++ b/Tests/SortedArrayTests/SortedArrayTests.swift
@@ -286,12 +286,12 @@ class SortedArrayTests: XCTestCase {
         assertElementsEqual(sut, [1,2])
     }
 
-    func testIsEqual() {
+    func testImplementsEqual() {
         let sut = SortedArray(unsorted: [3,2,1])
         XCTAssertTrue(sut == SortedArray(unsorted: 1...3))
     }
 
-    func testIsNotEqual() {
+    func testImplementsNotEqual() {
         let sut = SortedArray(unsorted: 1...3)
         XCTAssertTrue(sut != SortedArray(unsorted: 1...4))
     }
@@ -344,8 +344,8 @@ extension SortedArrayTests {
             ("testRemoveElementAtBeginningPreservesSortOrder", testRemoveElementAtBeginningPreservesSortOrder),
             ("testRemoveElementInMiddlePreservesSortOrder", testRemoveElementInMiddlePreservesSortOrder),
             ("testRemoveElementAtEndPreservesSortOrder", testRemoveElementAtEndPreservesSortOrder),
-            ("testImplements==", testIsEqual),
-            ("testImplements!=", testIsNotEqual),
+            ("testImplementsEqual", testImplementsEqual),
+            ("testImplementsNotEqual", testImplementsNotEqual),
         ]
     }
 }

--- a/scripts/travis-build-script.sh
+++ b/scripts/travis-build-script.sh
@@ -43,5 +43,5 @@ elif [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
     # Share the current directory (where Travis checked out the repository)
     # with the Docker container.
     # Then, in the container, cd into that directory and run the tests.
-    docker run --volume "$(pwd):/package" "${DOCKER_IMAGE}" /bin/bash -c "cd /package; swift --version; swift package clean; swift build; swift test --parallel"
+    docker run --volume "$(pwd):/package" "${DOCKER_IMAGE}" /bin/bash -c "cd /package; swift --version; swift package clean; swift build; swift test"
 fi

--- a/scripts/travis-build-script.sh
+++ b/scripts/travis-build-script.sh
@@ -15,7 +15,7 @@ if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     swift --version
     swift package clean
     swift build
-    swift test --parallel
+    swift test
 
     # 2. Test using xcodebuild
     echo -e "\nBuilding with xcodebuild\n========================"


### PR DESCRIPTION
Fixes #16.

I also added a `lastIndex(of:)` method. Among other things, you can use this together with index(of:) to find the range of duplicates of a single value in the array.