### PR TITLE
Added predicate-taking `searchFirst(where: …)` / `searchLast(where: …)`

### DIFF
--- a/Sources/SortedArray.swift
+++ b/Sources/SortedArray.swift
@@ -287,7 +287,7 @@ extension SortedArray {
     public func firstIndex(where predicate: (Element) throws -> Bool) rethrows -> Index? {
         var match: Index? = nil
         if case let .found(m) = try searchFirst(where: predicate) {
-			match = m
+            match = m
         }
         return match
     }
@@ -303,8 +303,8 @@ extension SortedArray {
     ///
     /// - Complexity: O(_log(n)_), where _n_ is the size of the array.
     public func first(where predicate: (Element) throws -> Bool) rethrows -> Element? {
-    	guard let index = try firstIndex(where: predicate) else { return nil }
-    	return self[index]
+        guard let index = try firstIndex(where: predicate) else { return nil }
+        return self[index]
     }
 
     /// Returns the first index where the specified value appears in the collection.
@@ -394,7 +394,7 @@ extension SortedArray {
     public func lastIndex(where predicate: (Element) throws -> Bool) rethrows -> Index? {
         var match: Index? = nil
         if case let .found(m) = try searchLast(where: predicate) {
-			match = m
+            match = m
         }
         return match
     }
@@ -410,8 +410,8 @@ extension SortedArray {
     ///
     /// - Complexity: O(_log(n)_), where _n_ is the size of the array.
     public func last(where predicate: (Element) throws -> Bool) rethrows -> Element? {
-    	guard let index = try firstIndex(where: predicate) else { return nil }
-    	return self[index]
+        guard let index = try firstIndex(where: predicate) else { return nil }
+        return self[index]
     }
 }
 
@@ -508,15 +508,15 @@ extension SortedArray {
     fileprivate func searchFirst(where predicate: (Element) throws -> Bool, in range: Range<Index>) rethrows -> Match<Index> {
         guard let middle = range.middle else { return .notFound(insertAt: range.upperBound) }
         if try predicate(self[middle]) {
-        	if middle == 0 {
-        		return .found(at: middle)
-        	} else if !(try predicate(self[index(before: middle)])) {
-        		return .found(at: middle)
-			} else {
-				return try searchFirst(where: predicate, in: range.lowerBound ..< middle)
-			}
+            if middle == 0 {
+                return .found(at: middle)
+            } else if !(try predicate(self[index(before: middle)])) {
+                return .found(at: middle)
+            } else {
+                return try searchFirst(where: predicate, in: range.lowerBound ..< middle)
+            }
         } else {
-        	return try searchFirst(where: predicate, in: index(after: middle) ..< range.upperBound)
+            return try searchFirst(where: predicate, in: index(after: middle) ..< range.upperBound)
         }
     }
     
@@ -547,15 +547,15 @@ extension SortedArray {
     fileprivate func searchLast(where predicate: (Element) throws -> Bool, in range: Range<Index>) rethrows -> Match<Index> {
         guard let middle = range.middle else { return .notFound(insertAt: range.upperBound) }
         if try predicate(self[middle]) {
-        	if middle == range.upperBound - 1 {
-        	return .found(at: middle)
-        	} else if !(try predicate(self[index(after: middle)])) {
-        		return .found(at: middle)
-			} else {
-				return try searchLast(where: predicate, in: index(after: middle) ..< range.upperBound)
-			}
+            if middle == range.upperBound - 1 {
+            return .found(at: middle)
+            } else if !(try predicate(self[index(after: middle)])) {
+                return .found(at: middle)
+            } else {
+                return try searchLast(where: predicate, in: index(after: middle) ..< range.upperBound)
+            }
         } else {
-        	return try searchLast(where: predicate, in: range.lowerBound ..< middle)
+            return try searchLast(where: predicate, in: range.lowerBound ..< middle)
         }
     }
 }

--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -26,6 +26,22 @@ class PerformanceTests: XCTestCase {
         }
     }
 
+    func testPerformanceOfFirstIndexWhere() {
+        let sourceArray = Array(repeating: 500, count: 1_000_000) + Array(repeating: 40, count: 1_000_000) + Array(repeating: 3, count: 1_000_000)
+        let sut = SortedArray(unsorted: sourceArray)
+        measure {
+            XCTAssertEqual(sut.firstIndex(where: { $0 >= 500 }), 2_000_000)
+        }
+    }
+
+    func testPerformanceOfLastIndexWhere() {
+        let sourceArray = Array(repeating: 500, count: 1_000_000) + Array(repeating: 40, count: 1_000_000) + Array(repeating: 3, count: 1_000_000)
+        let sut = SortedArray(unsorted: sourceArray)
+        measure {
+            XCTAssertEqual(sut.lastIndex(where: { $0 <= 3 }), 999_999)
+        }
+    }
+
     func testPerformanceOfIndexOfObject() {
         let sourceArray = Array(repeating: Box(500), count: 1_000_000) + Array(repeating: Box(40), count: 1_000_000) + Array(repeating: Box(3), count: 1_000_000)
         let sut = SortedArray(unsorted: sourceArray)
@@ -39,6 +55,22 @@ class PerformanceTests: XCTestCase {
         let sut = SortedArray(unsorted: sourceArray)
         measure {
             XCTAssertEqual(sut.lastIndex(of: Box(3)), 999_999)
+        }
+    }
+
+    func testPerformanceOfFirstIndexWhereObject() {
+        let sourceArray = Array(repeating: Box(500), count: 1_000_000) + Array(repeating: Box(40), count: 1_000_000) + Array(repeating: Box(3), count: 1_000_000)
+        let sut = SortedArray(unsorted: sourceArray)
+        measure {
+            XCTAssertEqual(sut.firstIndex(where: { $0 >= Box(500) }), 2_000_000)
+        }
+    }
+
+    func testPerformanceOfLastIndexWhereObject() {
+        let sourceArray = Array(repeating: Box(500), count: 1_000_000) + Array(repeating: Box(40), count: 1_000_000) + Array(repeating: Box(3), count: 1_000_000)
+        let sut = SortedArray(unsorted: sourceArray)
+        measure {
+            XCTAssertEqual(sut.lastIndex(where: { $0 <= Box(3) }), 999_999)
         }
     }
 
@@ -56,6 +88,20 @@ class PerformanceTests: XCTestCase {
             XCTAssertEqual(sut.lastIndex(of: Box(1_999_999)), 1_999_999)
         }
     }
+
+    func testPerformanceOfFirstIndexWhereObjectInRange() {
+        let sut = SortedArray(sorted: (0..<3_000_000).lazy.map(Box.init))
+        measure {
+            XCTAssertEqual(sut.firstIndex(where: { $0 >= Box(500) }), 500)
+        }
+    }
+
+    func testPerformanceOfLastIndexWhereObjectInRange() {
+        let sut = SortedArray(sorted: (0..<3_000_000).lazy.map(Box.init))
+        measure {
+            XCTAssertEqual(sut.lastIndex(where: { $0 <= Box(1_999_999) }), 1_999_999)
+        }
+    }
 }
 
 extension PerformanceTests {
@@ -64,10 +110,16 @@ extension PerformanceTests {
             ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
             ("testPerformanceOfIndexOf", testPerformanceOfIndexOf),
             ("testPerformanceOfLastIndexOf", testPerformanceOfLastIndexOf),
+            ("testPerformanceOfFirstIndexWhere", testPerformanceOfFirstIndexWhere),
+            ("testPerformanceOfLastIndexWhere", testPerformanceOfLastIndexWhere),
             ("testPerformanceOfIndexOfObject", testPerformanceOfIndexOfObject),
             ("testPerformanceOfLastIndexOfObject", testPerformanceOfLastIndexOfObject),
+            ("testPerformanceOfFirstIndexWhereObject", testPerformanceOfFirstIndexWhereObject),
+            ("testPerformanceOfLastIndexWhereObject", testPerformanceOfLastIndexWhereObject),
             ("testPerformanceOfIndexOfObjectInRange", testPerformanceOfIndexOfObjectInRange),
             ("testPerformanceOfLastIndexOfObjectInRange", testPerformanceOfLastIndexOfObjectInRange),
+            ("testPerformanceOfFirstIndexWhereObjectInRange", testPerformanceOfFirstIndexWhereObjectInRange),
+            ("testPerformanceOfLastIndexWhereObjectInRange", testPerformanceOfLastIndexWhereObjectInRange),
         ]
     }
 }

--- a/Tests/UnitTests/SortedArrayTests.swift
+++ b/Tests/UnitTests/SortedArrayTests.swift
@@ -175,6 +175,73 @@ class SortedArrayTests: XCTestCase {
         XCTAssertEqual(index, 2)
     }
 
+    func testFirstIndexWhereFindsElementInMiddle() {
+        let sut = SortedArray(unsorted: ["a","z","r","k"])
+        let index = sut.firstIndex(where: { $0 >= "k" })
+        XCTAssertEqual(index, 1)
+    }
+
+    func testFirstIndexWhereFindsFirstElement() {
+        let sut = SortedArray(sorted: 1..<10)
+        let index = sut.firstIndex(where: { $0 >= 1 })
+        XCTAssertEqual(index, 0)
+    }
+
+    func testFirstIndexWhereFindsLastElement() {
+        let sut = SortedArray(sorted: 1..<10)
+        let index = sut.firstIndex(where: { $0 >= 9 })
+        XCTAssertEqual(index, 8)
+    }
+
+    func testFirstIndexWhereReturnsNilWhenNotFound() {
+        let sut = SortedArray(unsorted: "Hello World")
+        let index = sut.firstIndex(where: { $0 > "z"})
+        XCTAssertNil(index)
+    }
+
+    func testFirstIndexWhereReturnsNilForEmptyArray() {
+        let sut = SortedArray<Int>()
+        let index = sut.firstIndex(where: { $0 >= 1 })
+        XCTAssertNil(index)
+    }
+
+    func testFirstIndexWhereCanDealWithSingleElementArray() {
+        let sut = SortedArray<Int>(unsorted: [5])
+        let index = sut.firstIndex(where: { $0 >= 5 })
+        XCTAssertEqual(index, 0)
+    }
+
+    func testFirstIndexWhereFindsFirstIndexOfDuplicateElements1() {
+        let sut = SortedArray(unsorted: [1,2,3,3,3,3,3,3,3,3,4,5])
+        let index = sut.firstIndex(where: { $0 >= 3 })
+        XCTAssertEqual(index, 2)
+    }
+
+    func testFirstIndexWhereFindsFirstIndexOfDuplicateElements2() {
+        let sut = SortedArray(unsorted: [1,4,4,4,4,4,4,4,4,3,2])
+        let index = sut.firstIndex(where: { $0 >= 4 })
+        XCTAssertEqual(index, 3)
+    }
+
+    func testFirstIndexWhereFindsFirstIndexOfDuplicateElements3() {
+        let sut = SortedArray(unsorted: String(repeating: "A", count: 10))
+        let index = sut.firstIndex(where: { $0 >= "A" })
+        XCTAssertEqual(index, 0)
+    }
+
+    func testFirstIndexWhereFindsFirstIndexOfDuplicateElements4() {
+        let sut = SortedArray<Character>(unsorted: Array(repeating: "a", count: 100_000))
+        let index = sut.firstIndex(where: { $0 >= "a" })
+        XCTAssertEqual(index, 0)
+    }
+
+    func testFirstIndexWhereFindsFirstIndexOfDuplicateElements5() {
+        let sourceArray = Array(repeating: 5, count: 100_000) + [1,2,6,7,8,9]
+        let sut = SortedArray(unsorted: sourceArray)
+        let index = sut.firstIndex(where: { $0 >= 5 })
+        XCTAssertEqual(index, 2)
+    }
+
     func testLastIndexOfFindsElementInMiddle() {
         let sut = SortedArray(unsorted: ["a","z","r","k"])
         let index = sut.lastIndex(of: "k")
@@ -226,6 +293,60 @@ class SortedArrayTests: XCTestCase {
     func testLastIndexOfFindsLastIndexOfDuplicateElements3() {
         let sut = SortedArray(unsorted: String(repeating: "A", count: 10))
         let index = sut.lastIndex(of: "A")
+        XCTAssertEqual(index, 9)
+    }
+
+    func testLastIndexWhereFindsElementInMiddle() {
+        let sut = SortedArray(unsorted: ["a","z","r","k"])
+        let index = sut.lastIndex(where: { $0 <= "k" })
+        XCTAssertEqual(index, 1)
+    }
+
+    func testLastIndexWhereFindsFirstElement() {
+        let sut = SortedArray(sorted: 1..<10)
+        let index = sut.lastIndex(where: { $0 <= 1 })
+        XCTAssertEqual(index, 0)
+    }
+
+    func testLastIndexWhereFindsLastElement() {
+        let sut = SortedArray(sorted: 1..<10)
+        let index = sut.lastIndex(where: { $0 <= 9 })
+        XCTAssertEqual(index, 8)
+    }
+
+    func testLastIndexWhereReturnsNilWhenNotFound() {
+        let sut = SortedArray(unsorted: "Hello World")
+        let index = sut.lastIndex(where: { $0 < " " })
+        XCTAssertNil(index)
+    }
+
+    func testLastIndexWhereReturnsNilForEmptyArray() {
+        let sut = SortedArray<Int>()
+        let index = sut.lastIndex(where: { $0 <= 1 })
+        XCTAssertNil(index)
+    }
+
+    func testLastIndexWhereCanDealWithSingleElementArray() {
+        let sut = SortedArray<Int>(unsorted: [5])
+        let index = sut.lastIndex(where: { $0 <= 5 })
+        XCTAssertEqual(index, 0)
+    }
+
+    func testLastIndexWhereFindsLastIndexOfDuplicateElements1() {
+        let sut = SortedArray(unsorted: [1,2,3,3,3,3,3,3,3,3,4,5])
+        let index = sut.lastIndex(where: { $0 <= 3 })
+        XCTAssertEqual(index, 9)
+    }
+
+    func testLastIndexWhereFindsLastIndexOfDuplicateElements2() {
+        let sut = SortedArray(unsorted: [1,4,4,4,4,4,4,4,4,3,2])
+        let index = sut.lastIndex(where: { $0 <= 4 })
+        XCTAssertEqual(index, 10)
+    }
+
+    func testLastIndexWhereFindsLastIndexOfDuplicateElements3() {
+        let sut = SortedArray(unsorted: String(repeating: "A", count: 10))
+        let index = sut.lastIndex(where: { $0 <= "A" })
         XCTAssertEqual(index, 9)
     }
 
@@ -400,6 +521,17 @@ extension SortedArrayTests {
             ("testIndexOfFindsFirstIndexOfDuplicateElements4", testIndexOfFindsFirstIndexOfDuplicateElements4),
             ("testIndexOfFindsFirstIndexOfDuplicateElements5", testIndexOfFindsFirstIndexOfDuplicateElements4),
             ("testIndexOfExistsAndIsAnAliasForFirstIndexOf", testIndexOfExistsAndIsAnAliasForFirstIndexOf),
+            ("testFirstIndexWhereFindsElementInMiddle", testFirstIndexWhereFindsElementInMiddle),
+            ("testFirstIndexWhereFindsFirstElement", testFirstIndexWhereFindsFirstElement),
+            ("testFirstIndexWhereFindsLastElement", testFirstIndexWhereFindsLastElement),
+            ("testFirstIndexWhereReturnsNilWhenNotFound", testFirstIndexWhereReturnsNilWhenNotFound),
+            ("testFirstIndexWhereReturnsNilForEmptyArray", testFirstIndexWhereReturnsNilForEmptyArray),
+            ("testFirstIndexWhereCanDealWithSingleElementArray", testFirstIndexWhereCanDealWithSingleElementArray),
+            ("testFirstIndexWhereFindsFirstIndexOfDuplicateElements1", testFirstIndexWhereFindsFirstIndexOfDuplicateElements1),
+            ("testFirstIndexWhereFindsFirstIndexOfDuplicateElements2", testFirstIndexWhereFindsFirstIndexOfDuplicateElements2),
+            ("testFirstIndexWhereFindsFirstIndexOfDuplicateElements3", testFirstIndexWhereFindsFirstIndexOfDuplicateElements3),
+            ("testFirstIndexWhereFindsFirstIndexOfDuplicateElements4", testFirstIndexWhereFindsFirstIndexOfDuplicateElements4),
+            ("testFirstIndexWhereFindsFirstIndexOfDuplicateElements5", testFirstIndexWhereFindsFirstIndexOfDuplicateElements5),
             ("testLastIndexOfFindsElementInMiddle", testLastIndexOfFindsElementInMiddle),
             ("testLastIndexOfFindsFirstElement", testLastIndexOfFindsFirstElement),
             ("testLastIndexOfFindsLastElement", testLastIndexOfFindsLastElement),
@@ -409,6 +541,15 @@ extension SortedArrayTests {
             ("testLastIndexOfFindsLastIndexOfDuplicateElements1", testLastIndexOfFindsLastIndexOfDuplicateElements1),
             ("testLastIndexOfFindsLastIndexOfDuplicateElements2", testLastIndexOfFindsLastIndexOfDuplicateElements2),
             ("testLastIndexOfFindsLastIndexOfDuplicateElements3", testLastIndexOfFindsLastIndexOfDuplicateElements3),
+            ("testLastIndexWhereFindsElementInMiddle", testLastIndexWhereFindsElementInMiddle),
+            ("testLastIndexWhereFindsFirstElement", testLastIndexWhereFindsFirstElement),
+            ("testLastIndexWhereFindsLastElement", testLastIndexWhereFindsLastElement),
+            ("testLastIndexWhereReturnsNilWhenNotFound", testLastIndexWhereReturnsNilWhenNotFound),
+            ("testLastIndexWhereReturnsNilForEmptyArray", testLastIndexWhereReturnsNilForEmptyArray),
+            ("testLastIndexWhereCanDealWithSingleElementArray", testLastIndexWhereCanDealWithSingleElementArray),
+            ("testLastIndexWhereFindsLastIndexOfDuplicateElements1", testLastIndexWhereFindsLastIndexOfDuplicateElements1),
+            ("testLastIndexWhereFindsLastIndexOfDuplicateElements2", testLastIndexWhereFindsLastIndexOfDuplicateElements2),
+            ("testLastIndexWhereFindsLastIndexOfDuplicateElements3", testLastIndexWhereFindsLastIndexOfDuplicateElements3),
             ("testsContains", testsContains),
             ("testMin", testMin),
             ("testMax", testMax),


### PR DESCRIPTION
Created new `firstIndex(where:)`/`lastIndex(where:)` and `first(where:)`/`last(where:)` methods to match the APIs of `Collection` & `Sequence`, and to fill the gap in my app left by the no-longer-updated `ExSwift` library.  Backed by private `searchFirst(where:)` & `searchLast(where:)`.

These are useful for a variety of situations where situations where `firstIndex(of:)`/`lastIndex(of:)` don't cut it:

* When you're searching in an array of ordered values for something beyond a certain point, e.g. an array of `TimeInterval`s.
* When you're searching in a `Float`/`Double` array for a value that's “close enough” to a given value, since floating point numbers tend to lose precision the more calculations they've been though.
* When you need to construct or decompose a data type in order to do a proper comparison.


The main caveat here is that not only do the elements need to be sorted _(a great fit for `SortedArray`)_, but the `where:` predicate also needs to return a boolean based on that sorting— for `searchFirst(where:)` the predicate must return `false` up to a certain point and `true` from that point on; and for `searchLast(where:)` the opposite— the predicate must return `true` up to a certain point and `false` from that point on.  It's a little weird to have this constraint listed in doc-comments but not enforced in code in any way.  But… this is how `ExSwift`'s `bSearch(_:)` worked, which was based on Ruby's `Array`'s `bsearch` method, and sometimes you just need a closure-check.

I also realized when implementing tests that nearly every predicate for `firstIndex(where:)` is going to use `{ $0 > … }` or `{ $0 >= … }`, and every predicate for `lastIndex(where:)` is going to use `{ $0 < … }` or `{ $0 <= … }`.  That makes me think that these methods would be better exposed as something like `firstIndex(whichIsGreaterThan:Element)` and `firstIndex(whichIsGreaterThanOrEqualTo:Element)`, so that we can still enforce the `false`-`true` ordering of the results while allowing searching for a value that isn't specifically in the array.

So I'm on the fence about the validity of my own approach.  There's precedent in other languages/libs and existing API in Swift, but it feels too “loose”.  That said, I have one situation in my own app that can only work with `first(where:)` and would be a huge performance hit if it were a linear search.  I have a `UIBezierPath` that curves from (0, 0) up to (1, 1), then boxes the area in with a line to (1, 0) and a line back to (0, 0) _(screenshot at [cl.ly/dc5fa1](https://cl.ly/dc5fa1))_.  Later on, I need to find the X coordinate for a given Y coordinate on that curve, and I'm accomplishing that by creating a `stride(from:,through:,by:)` of X coords and binary searching them to find the first one where `path.contains(CGPoint(x: x, y: y))`.  That's something that would be difficult to accomplish through other means.  There has to be a whole world of esoteric search situations out there that could benefit from open-ended `where:` methods.

So let me know your thoughts— whether we should just merge this, or merge this and add `firstIndex(whichIsGreaterThan:)`/etc. methods, or something else.  I'd like to make the best contribution I can to the only real `SortedArray` lib I could find for Swift.  _(But on the other hand, I can't finish upgrading my app from Swift 3 to Swift 5 and continue with feature development until I've found or written a replacement for ExSwift's `bSearch(_:)`, and I'd prefer to be using an open-source lib rather than just adding private binary search functions throughout my project)._


### Change details:

* Created **`searchFirst(where:)` & `searchFirst(where:,in:)` private methods**, in the style of `SortedArray`'s `search(for:)` and `Collection`'s `firstIndex(where:)`, using the “find-minimum mode” algorithm from ExSwift's `bSearch(_:)` and Ruby's `bsearch_index`.  Requires that the predicate return `false` for elements up to a point, and `true` for elements after; more about this at the `- Requires:` doc-comments.
* Created **`firstIndex(where:)` & `first(where:)` public methods**, matching the API of `Collection`'s and `Sequence`'s methods.  The latter method uses the former, and the former uses `searchFirst(where:)`.
* Created **`searchLast(where:)` & `searchLast(where:,In:)` private methods**, in the style of `SortedArray`'s `search(for:)` and `Collection`'s `lastIndex(where:)`, using the a variant of Ruby's `bsearch_index` but doing an opposite “find-maximum mode” algorithm.  Requires that the predicate return `true` for elements up to a point, and `false` for elements after _(the opposite of `searchFirst(where:)`)_; more about this at the `- Requires:` doc-comments.
* Created **`lastIndex(where:)` & `last(where:)` public methods**, matching the API of `Collection`'s and `Sequence`'s methods.  The latter method uses the former, and the former uses `searchLast(where:)`.
* Added **logic & performance tests** for `firstIndex(where:)` & `lastIndex(where:)`, mirroring the existing tests for `firstIndex(of:)` & `lastIndex(of:)`.